### PR TITLE
refactor: generalize project template

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,36 @@
+# Development Guide
+
+本说明文档帮助开发者在 `OpenSketch` 项目基础上进行二次开发或接入不同的 AIGC 服务。
+
+## 目录结构
+
+- `pages/draw/draw.vue`：主要的画板逻辑与接口调用。
+- `utils/api-config.js`：统一管理后端接口地址，可切换不同的服务。
+- `server/upload_server.py`：示例上传服务器，接收前端生成的图片。
+
+## 更换或新增后端服务
+
+1. 在 `utils/api-config.js` 中修改默认的 `sdTxt2Img` 和 `sdImg2Img` 地址，使其指向你自己的 Stable Diffusion WebUI。
+2. 若使用 [ComfyUI](https://github.com/comfyanonymous/ComfyUI)，可在该文件中设置 `comfyUIPrompt`，并在 `pages/draw/draw.vue` 中按需新增调用逻辑。
+3. 若接入其他模型，只需在配置文件中添加新的端点，并在前端方法中使用对应的地址即可。
+
+## 自定义主题与界面
+
+- 在 `pages` 目录下新增或修改页面，即可更换界面主题。
+- 使用 `uView` 组件库可快速搭建常见 UI 组件。
+
+## 上传服务器
+
+示例服务器位于 `server/upload_server.py`，其功能极简，只负责接收 POST 上传的图片并保存到 `server/uploads/` 目录。实际部署时可以：
+
+- 增加用户鉴权；
+- 将文件保存到云存储；
+- 根据业务需求返回自定义的响应。
+
+## 构建与运行
+
+使用 [HBuilderX](https://www.dcloud.io/hbuilderx.html) 或其它支持 `uni-app` 的环境打开项目，根据目标平台编译或运行。
+
+## 贡献
+
+欢迎提交 Issue 或 PR 来改进项目模板。

--- a/README.md
+++ b/README.md
@@ -1,18 +1,17 @@
-# SwimWorld
+# OpenSketch
 
-SwimWorld 是一个基于 [uni-app](https://uniapp.dcloud.io/) 的小程序，
-用于与 Stable Diffusion 接口交互生成“泳动小精灵”图像。用户可以
-输入文本并通过滑动手势上传生成的图像进行分享。
+OpenSketch 是一个基于 [uni-app](https://uniapp.dcloud.io/) 的模板工程，支持在移动端或小程序端的画板上涂鸦，并将图像发送到可配置的 AIGC 后端（如 Stable Diffusion WebUI、ComfyUI 等）进行生成。项目同时附带一个简易的上传服务器，用于接收并保存生成的图片。
 
 ## 功能特点
 
-- 通过 AI 生成自定义的泳动小精灵图像；
-- 支持滑动触发上传，显示剩余上传次数；
-- 内置 [uView](https://www.uviewui.com/) 组件库以构建界面。
+- 画板涂鸦并调用 AI 生成图像；
+- API 端点可在 `utils/api-config.js` 中配置，以便对接不同的模型或服务；
+- 内置 [uView](https://www.uviewui.com/) 组件库构建界面；
+- 提供上传服务器示例，便于二次开发。
 
 ## 服务说明
 
-- **Stable Diffusion 接口**：依赖 SD WebUI，默认提供 `7860` 端口的 HTTP API。
+- **AIGC 接口**：默认对接 Stable Diffusion WebUI，端口和地址可在 `utils/api-config.js` 中修改，也可替换为 ComfyUI 等其它服务；
 - **上传服务器**：`server/upload_server.py` 使用 [Flask](https://flask.palletsprojects.com/) 接收图片，默认监听 `5000` 端口，并将文件保存到 `server/uploads/` 目录。
 
 ### 启动上传服务器
@@ -29,13 +28,9 @@ python server/upload_server.py
 1. 使用 HBuilderX 或其他支持 `uni-app` 的环境打开本项目；
 2. 根据目标平台进行编译或运行（如微信小程序、H5 等）。
 
-## 相关论文
+## 开发
 
-基于本项目的研究成果：
-
-- *(CHI2025) The Immersive Art Therapy Driven by AIGC: An Innovative Approach to Alleviating Children's Nyctophobia*  
-  Authors: Jinlin Miao, Zhiyuan Zhou, Yilei Wu, Fenggui Rao*, Fanjing Meng*  
-  *:共同通讯作者
+项目的结构、接口切换和二次开发说明见 [DEVELOPMENT.md](DEVELOPMENT.md)。
 
 ## 许可证
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "hubinPING",
+  "name": "OpenSketch",
   "appid": "__UNI__AFADA37",
   "description": "",
   "versionName": "1.0.0",

--- a/pages/draw/draw.vue
+++ b/pages/draw/draw.vue
@@ -83,6 +83,7 @@
 </template>
 
 <script>
+  import apiConfig from '../../utils/api-config.js'
   const url = 'https://www.zebbagreen.cn/FZLTSJW.TTF'
 
 
@@ -98,6 +99,8 @@
         uploadedImage: null,
         generatedImage: null,
         base64Image: '',
+        // current backend, see utils/api-config.js
+        backend: apiConfig.backend,
 
         //手指动画的参数
         imageSrc: 'https://www.zebbagreen.cn/static/手指.svg',
@@ -475,7 +478,7 @@
 
       // Method to send the converted image
       sendImage() {
-        const url = 'https://gt29495501.yicp.fun/sdapi/v1/txt2img'; // Replace with your server address
+        const url = apiConfig.sdTxt2Img; // configurable endpoint
 
         const params = {
           prompt: 'A flat image of ip, logo or a symbol, it is' + this.prompt,
@@ -537,7 +540,7 @@
       },
 
       sendImage2() {
-        const url = 'https://gt29495501.yicp.fun/sdapi/v1/img2img'; // Replace with your server address
+        const url = apiConfig.sdImg2Img; // configurable endpoint
 
         const params = {
           init_images: [this.base64Image],

--- a/utils/api-config.js
+++ b/utils/api-config.js
@@ -1,0 +1,9 @@
+export default {
+  // default backend type; change to 'comfyui' to use ComfyUI
+  backend: 'stableDiffusion',
+  // Stable Diffusion WebUI endpoints
+  sdTxt2Img: 'http://localhost:7860/sdapi/v1/txt2img',
+  sdImg2Img: 'http://localhost:7860/sdapi/v1/img2img',
+  // ComfyUI endpoint for advanced pipelines (not used by default)
+  comfyUIPrompt: 'http://localhost:8188/api/prompt'
+};


### PR DESCRIPTION
## Summary
- rename project to OpenSketch and document configuration options
- centralize backend endpoints in utils/api-config.js for Stable Diffusion and ComfyUI
- add development guide for customizing backends, themes, and server

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891e05fa248832ebd6b6a838eb9f283